### PR TITLE
[ISSUE-13] Add Disbursement Job and Service

### DIFF
--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Disbursement < ApplicationRecord
+  validates :reference,
+    presence: true,
+    uniqueness: true
+  
+  belongs_to :merchant
+
+  has_many :orders
+
+  def first_merchant_month_disbursement?
+    merchant.disbursements.where(
+      year_month: year_month
+    ).one?
+  end
+
+  def verify_debit
+    register_debit if merchant.debit?
+  end
+
+  def register_debit
+    merchant.monthly_fee_debits.create!(
+      amount: merchant.debit_amount,
+      disbursement_id: self.id,
+    )
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,8 +2,8 @@
 
 class Merchant < ApplicationRecord
   VALID_DISBURSEMENT_FREQUENCIES = [
-    WEEKLY  = "WEEKLY",
-    DAILY  = "DAILY",
+    WEEKLY = "WEEKLY",
+    DAILY = "DAILY",
   ].freeze
 
   validates :uid,
@@ -19,4 +19,52 @@ class Merchant < ApplicationRecord
       in: VALID_DISBURSEMENT_FREQUENCIES,
       message: "Invalid Disbursement Frequency"
     }
+  
+  has_many :orders
+  has_many :disbursements
+  has_many :monthly_fee_debits
+
+  scope :ready_for_disbursement, -> {
+    where(disbursement_frequency: DAILY)
+    .or(
+      where(
+        "disbursement_frequency = :frequency AND EXTRACT(DOW FROM live_on) = :weekday",
+        frequency: WEEKLY,
+        weekday: Date.today.wday,
+      )
+    )
+  }
+
+  def debit?
+    debit_amount > 0 
+  end
+
+  def debit_amount
+    debit = (minimum_monthly_fee - paid_fee(previous_year_month)).round(2)
+
+    [debit, 0].max
+  end
+
+  def paid_fee(year_month)
+    disbursements.
+      where(year_month: year_month).
+      sum(:commision_fee)
+  end
+
+  def create_disbursement!
+    disbursements.create!(
+      reference: disbursement_reference,
+      year_month: Date.today.strftime('%Y_%m'),
+      amount: 0.0,
+      commision_fee: 0.0,
+    )
+  end
+
+  def previous_year_month
+    Date.today.last_month.strftime('%Y_%m')
+  end
+
+  def disbursement_reference
+    "#{reference}_#{Date.today.strftime("%Y%m%d")}"
+  end
 end

--- a/app/models/monthly_fee_debit.rb
+++ b/app/models/monthly_fee_debit.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class MonthlyFeeDebit < ApplicationRecord
+  belongs_to :merchant
+  belongs_to :disbursement
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,8 +2,25 @@
 
 class Order < ApplicationRecord
   belongs_to :merchant
+  belongs_to :disbursement, optional: true
 
   validates :uid,
     presence: true,
     uniqueness: true
+
+  scope :needs_disbursement, -> { where(disbursed: false) }
+
+  def calculated_commision_fee
+    commission_rate = case amount
+      when 0...50 then 0.01
+      when 50...300 then 0.0095
+      else 0.0085
+    end
+
+    (amount * commission_rate).round(2) 
+  end
+
+  def calculated_net_amount
+    (amount - calculated_commision_fee).round(2)
+  end
 end

--- a/app/services/disbursement_service.rb
+++ b/app/services/disbursement_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class DisbursementService
+  attr_reader :merchant, :disbursement
+
+  def initialize(merchant)
+    @merchant = merchant
+    @disbursement = merchant.create_disbursement!
+  end
+
+  def run
+    disbursement.verify_debit if disbursement.first_merchant_month_disbursement?
+
+    merchant.orders.needs_disbursement.each do |order|
+      disburse(order)
+    end
+  end
+
+  def disburse(order)
+    ActiveRecord::Base.transaction do
+      process_disbursement(order)
+      process_order(order)
+    end
+  end
+
+  def process_disbursement(order)
+    disbursement.amount += order.calculated_net_amount
+    disbursement.commision_fee += order.calculated_commision_fee
+    disbursement.save!
+  end
+
+  def process_order(order)
+    order.disbursement = disbursement
+    order.disbursed = true
+    order.save!
+  end
+end

--- a/app/sidekiq/disbursement_job.rb
+++ b/app/sidekiq/disbursement_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'sidekiq-scheduler'
+
+class DisbursementJob
+  include Sidekiq::Worker
+
+  def perform
+    disburse_orders
+  end
+
+  def disburse_orders
+    Merchant.ready_for_disbursement.each do |merchant|
+      DisbursementService.new(merchant).run
+    end
+  end
+end

--- a/db/migrate/20231118175527_create_disbursements.rb
+++ b/db/migrate/20231118175527_create_disbursements.rb
@@ -1,0 +1,13 @@
+class CreateDisbursements < ActiveRecord::Migration[6.1]
+  def change
+    create_table :disbursements do |t|
+      t.references :merchant, foreign_key: true, index: true      
+      t.string :reference, null: false
+      t.float :amount
+      t.float :commision_fee
+      t.string :year_month
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231118180229_add_disbursement_to_orders.rb
+++ b/db/migrate/20231118180229_add_disbursement_to_orders.rb
@@ -1,0 +1,7 @@
+class AddDisbursementToOrders < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :orders, :disbursement, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20231118180655_create_monthly_fee_debits.rb
+++ b/db/migrate/20231118180655_create_monthly_fee_debits.rb
@@ -1,0 +1,11 @@
+class CreateMonthlyFeeDebits < ActiveRecord::Migration[6.1]
+  def change
+    create_table :monthly_fee_debits do |t|
+      t.references :merchant, foreign_key: true, index: true
+      t.references :disbursement, foreign_key: true, index: true
+      t.float :amount
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231119222041_add_index_to_merchant_reference.rb
+++ b/db/migrate/20231119222041_add_index_to_merchant_reference.rb
@@ -1,0 +1,7 @@
+class AddIndexToMerchantReference < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :merchants, :reference, unique: true, algorithm: :concurrently
+  end
+end

--- a/spec/factories/disbursements.rb
+++ b/spec/factories/disbursements.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :disbursement do
+    merchant
+    reference { SecureRandom.alphanumeric(10) }
+    year_month { "2023_02" }
+    amount { 0.0  }
+    commision_fee { 0.0 }
+  end
+end

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -1,10 +1,18 @@
 FactoryBot.define do
   factory :merchant do
     uid { SecureRandom.uuid }
+    disbursement_frequency { Merchant::DAILY }
     reference { SecureRandom.alphanumeric(10) }
     email { "info@padberg-group.com" }
     live_on { 2.months.ago }
-    disbursement_frequency { "DAILY" }
     minimum_monthly_fee { 100.0 }
+
+    trait :daily do
+      disbursement_frequency { Merchant::DAILY }
+    end
+
+    trait :weekly do
+      disbursement_frequency { Merchant::WEEKLY }
+    end
   end
 end

--- a/spec/factories/monthly_fee_debits.rb
+++ b/spec/factories/monthly_fee_debits.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :monthly_fee_debit do
+    merchant
+    amount { 10.0 }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     merchant
     amount { 100.0 }
     creation_date { 2.months.ago }
+
+    trait :disbursed do
+      disbursed { true }
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Merchant do
-  before { create(:merchant) }
-
   context "validations" do
+    before { create(:merchant) }
+
     it { should validate_presence_of(:uid) }
     it { should validate_uniqueness_of(:uid) }
     it { should validate_presence_of(:reference) }
@@ -15,6 +15,24 @@ RSpec.describe Merchant do
       is_expected.to validate_inclusion_of(:disbursement_frequency)
         .in_array(Merchant::VALID_DISBURSEMENT_FREQUENCIES)
         .with_message(/Invalid Disbursement Frequency/)
+    end
+  end
+
+  describe "scopes" do
+    describe ".ready_for_disbursement" do
+      subject { Merchant.ready_for_disbursement }
+
+      let(:today) { Date.today }
+      let(:weekday) { Date::DAYNAMES[today.wday].downcase.to_sym }
+      let(:same_weekday) { Date.today.weeks_ago(1).beginning_of_week(weekday) }
+
+      let!(:daily_merchant) { create(:merchant, :daily) }
+      let!(:weekly_merchant_live_on_same_weekday) { create(:merchant, :weekly, live_on: same_weekday) }
+      let!(:weekly_merchant_live_on_different_weekday) { create(:merchant, :weekly, live_on: 2.days.ago) }
+
+      it "should return only the merchants that are ready to be disbursed" do
+        expect(subject).to match_array([daily_merchant, weekly_merchant_live_on_same_weekday])
+      end
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -3,14 +3,28 @@
 require "rails_helper"
 
 RSpec.describe Order do
-  before { create(:order) }
-
   describe "associations" do
     it { is_expected.to belong_to(:merchant) }
   end
 
   context "validations" do
+    before { create(:order) }
+
     it { should validate_presence_of(:uid) }
     it { should validate_uniqueness_of(:uid) }
+  end
+
+  describe "scopes" do
+    describe ".needs_disbursement" do
+      let!(:orders_not_disbursed) { create_list(:order, 5, disbursed: false) }
+
+      before do
+        create_list(:order, 5, disbursed: true)
+      end
+
+      it "should return only the orders that needs disbursement" do
+        expect(Order.needs_disbursement).to match_array(orders_not_disbursed)
+      end
+    end
   end
 end

--- a/spec/services/disbursement_service_spec.rb
+++ b/spec/services/disbursement_service_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe DisbursementService do
+  describe "#run" do
+    subject { DisbursementService.new(merchant).run }
+
+    let(:today) { Date.today }
+    let(:weekday) { Date::DAYNAMES[today.wday].downcase.to_sym }
+    let(:same_weekday) { today.weeks_ago(1).beginning_of_week(weekday) }
+
+    let(:minimum_monthly_fee) { 30.00 }
+    let(:merchant) { create(:merchant, :daily, minimum_monthly_fee: minimum_monthly_fee) }
+
+    let!(:order1) { create(:order, disbursed: false, amount: 10.25, merchant: merchant) }
+    let!(:order2) { create(:order, disbursed: false, amount: 89.56, merchant: merchant) }
+    let!(:order3) { create(:order, disbursed: false, amount: 378.46, merchant: merchant) }
+    let!(:order4) { create(:order, disbursed: false, amount: 49.99, merchant: merchant) }
+    let!(:order5) { create(:order, disbursed: false, amount: 50.00, merchant: merchant) }
+    let!(:order6) { create(:order, disbursed: false, amount: 50.01, merchant: merchant) }
+    let!(:order7) { create(:order, disbursed: false, amount: 299.99, merchant: merchant) }
+    let!(:order8) { create(:order, disbursed: false, amount: 300.00, merchant: merchant) }
+    let!(:order9) { create(:order, disbursed: false, amount: 300.01, merchant: merchant) }
+
+    let(:orders_to_disburse) { [order1.reload, order2.reload, order3.reload, order4.reload, order5.reload, order6.reload, order7.reload, order8.reload, order9.reload] }
+    let(:this_year_month) { today.strftime('%Y_%m') }
+    let(:previous_year_month) { today.last_month.strftime('%Y_%m') }
+    let(:disbursement) { merchant.disbursements.where(year_month: this_year_month).last }
+
+    before do
+      create_list(:order, 5, disbursed: true, amount: 10.00, merchant: merchant)
+    end
+
+    it "should disburse orders with the right amount and commission fee" do
+      subject
+
+      expect(orders_to_disburse.pluck(:disbursed).uniq.first).to be_truthy
+      expect(orders_to_disburse.pluck(:disbursement_id).uniq.first).to eq(disbursement.id)
+
+      expect(Disbursement.count).to eq(1)
+      expect(disbursement).to have_attributes(
+        merchant_id: merchant.id,
+        reference: "#{merchant.reference}_#{today.strftime("%Y%m%d")}",
+        amount: 10.15 + 88.71 + 375.24 + 49.49 + 49.52 + 49.53 + 297.14 + 297.45 + 297.46,
+        commision_fee: 0.10 + 0.85 + 3.22 + 0.50 + 0.48 + 0.48 + 2.85 + 2.55 + 2.55, 
+        year_month: this_year_month,
+      )
+
+      expect(MonthlyFeeDebit.count).to eq(1)
+      expect(MonthlyFeeDebit.last).to have_attributes(
+        merchant_id: merchant.id,
+        disbursement_id: disbursement.id,
+        amount: minimum_monthly_fee,
+      )
+    end
+
+    it "should calculate monthly fee debit correctly if there is debit" do
+      create(:disbursement, merchant: merchant, year_month: previous_year_month, commision_fee: 5.00)
+      create(:disbursement, merchant: merchant, year_month: previous_year_month, commision_fee: 15.00)
+      create(:disbursement, merchant: merchant, year_month: previous_year_month, commision_fee: 9.99)
+
+      subject
+
+      expect(MonthlyFeeDebit.count).to eq(1)
+      expect(MonthlyFeeDebit.last).to have_attributes(
+        merchant_id: merchant.id,
+        disbursement_id: disbursement.id,
+        amount: 0.01,
+      )
+    end
+
+    it "should not register monthly fee debit if there is no debit" do
+      create(:disbursement, merchant: merchant, year_month: previous_year_month, commision_fee: 5.01)
+      create(:disbursement, merchant: merchant, year_month: previous_year_month, commision_fee: 15.00)
+      create(:disbursement, merchant: merchant, year_month: previous_year_month, commision_fee: 9.99)
+
+      subject
+
+      expect(MonthlyFeeDebit.count).to be_zero
+    end
+  end
+end

--- a/spec/sidekiq/disbursement_job_spec.rb
+++ b/spec/sidekiq/disbursement_job_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe DisbursementJob do
+
+  describe "#perform" do
+    subject { DisbursementJob.new }
+
+    let(:today) { Date.today }
+    let(:weekday) { Date::DAYNAMES[today.wday].downcase.to_sym }
+    let(:same_weekday) { today.weeks_ago(1).beginning_of_week(weekday) }
+
+    let!(:daily_merchant) { create(:merchant, :daily) }
+    let!(:weekly_merchant) { create(:merchant, :weekly, live_on: same_weekday) }
+    let!(:weekly_merchant_different_weekday) { create(:merchant, :weekly, live_on: 2.days.ago) }
+
+    it "should call disbursement service with the right values" do
+      expect(DisbursementService).to receive(:new).
+        with(daily_merchant).
+        and_return(double("Disbursement Service Instance 1", run: true))
+
+      expect(DisbursementService).to receive(:new).
+        with(weekly_merchant).
+        and_return(double("Disbursement Service Instance 2", run: true))
+
+      expect(DisbursementService).not_to receive(:new).
+        with(weekly_merchant_different_weekday)
+
+      subject.perform
+    end
+  end
+end


### PR DESCRIPTION
Adressing Issue https://github.com/fernandesleticia/merchantsdisbursementspayouts/issues/13

- DisbursementJob

    Schedule the disbursement calculation process to run daily at 00:00 UTC.
    Identify merchants eligible for daily or weekly disbursements based on their configured frequencies.
    Trigger the Disbursement Service to perform calculations and update the database accordingly.

 - DisbursementService

    Calculate disbursements for merchants based on the specified criteria.
    Apply commission fees to orders according to the provided pricing rules.
    Ensure that disbursements are unique and have a unique alphanumerical reference.
    Handle the rounding up of commission fees to two decimal places.
    Handle the first disbursement of each month to ensure the minimum monthly fee is reached.