### PR TITLE
[ISSUE-15] Bulk inserting orders

### DIFF
--- a/app/importers/base_csv_importer.rb
+++ b/app/importers/base_csv_importer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BaseCsvImporter
   BATCH_SIZE = 20
   COMMON_DELIMITERS = ['","', '";"', "\"\t\""].freeze
@@ -27,8 +29,6 @@ class BaseCsvImporter
     @batch= []
     result_output_stream.write(result_output_stream_header)
 
-    start = Time.current
-
     col_sep = sniff_column_separator(input_csv_file)
 
     CSV.foreach(input_csv_file, headers: true, encoding: "ISO-8859-1", col_sep: col_sep).with_index do |row|
@@ -51,5 +51,21 @@ class BaseCsvImporter
     return if valid_row?(row)
 
     raise StandardError, "Data missing"
+  end
+
+  def result_output_stream_header
+    CSV.generate_line(["error", "batch", "row"])
+  end
+
+  def log(error, batch, row: nil)
+    result_output_stream.write(
+      CSV.generate_line(
+        [
+          error,
+          batch.map(&:to_h),
+          row.to_h
+        ]
+      )
+    )
   end
 end

--- a/app/importers/merchant_csv_importer.rb
+++ b/app/importers/merchant_csv_importer.rb
@@ -1,31 +1,38 @@
 
+# frozen_string_literal: true
+
 class MerchantCsvImporter < BaseCsvImporter
   def process_batch
-    batch_with_error = false
-    merchants_to_process = []
-
-    @batch.each do |row|
-      validates_data(row)
-      Merchant.create!(
-        uid: row["id"],
-        reference: row["reference"],
-        email: row["email"],
-        live_on: Date.parse(row["live_on"]),
-        disbursement_frequency: row["disbursement_frequency"],
-        minimum_monthly_fee: row["minimum_monthly_fee"],
-      )
+    begin
+      Merchant.import columns, merchants, validate: true
     rescue StandardError => e
       batch_with_error = true
-      log(e.message, row)
-      next
+      log(e.message, @batch)
     end
 
     @batch = []
-    write_dot(batch_with_error)
   end
 
-  def result_output_stream_header
-    CSV.generate_line(["error", "id", "reference", "email", "live_on", "disbursement_frequency", "minimum_monthly_fee"])
+  def columns
+    %i[uid reference email live_on disbursement_frequency minimum_monthly_fee]
+  end
+
+  def merchants
+    batch_with_error = false
+    merchants = []
+
+    @batch.each do |row|
+      validates_data(row)
+
+      merchants << [row["id"], row["reference"], row["email"], Date.parse(row["live_on"]), row["disbursement_frequency"], row["minimum_monthly_fee"]]
+    rescue StandardError => e
+      batch_with_error = true
+      log(e.message, @batch, row: row)
+      next
+    end
+
+    write_dot(batch_with_error)
+    merchants
   end
 
   def valid_row?(row)
@@ -35,21 +42,5 @@ class MerchantCsvImporter < BaseCsvImporter
     row["live_on"].present? &&
     row["disbursement_frequency"].present? &&
     row["minimum_monthly_fee"].present?
-  end
-
-  def log(error, row)
-    result_output_stream.write(
-      CSV.generate_line(
-        [
-          error,
-          row["id"],
-          row["reference"],
-          row["email"],
-          row["live_on"],
-          row["disbursement_frequency"],
-          row["minimum_monthly_fee"],
-        ]
-      )
-    )
   end
 end

--- a/lib/tasks/import_orders.rake
+++ b/lib/tasks/import_orders.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :orders do
-  desc "Import Order"
+  desc "Import Orders"
 
   task :import, [:csvfile] => [:environment] do |_task, args|
     orders_csv_file_path = args[:csvfile]

--- a/spec/fixtures/files/merchants.csv
+++ b/spec/fixtures/files/merchants.csv
@@ -1,2 +1,2 @@
 id,reference,email,live_on,disbursement_frequency,minimum_monthly_fee
-86312006-4d7e-45c4-9c28-788f4aa68a62,padberg_group,info@padberg-group.com,invalid_date,DAILY,0.0
+86312006-4d7e-45c4-9c28-788f4aa68a62,padberg_group,info@padberg-group.com,2010-02-03,DAILY,0.0

--- a/spec/fixtures/files/orders.csv
+++ b/spec/fixtures/files/orders.csv
@@ -1,2 +1,3 @@
 id,merchant_reference,amount,created_at
-e653f3e14bc4,padberg_group,50.0,2022-01-01
+e653f3e14bc4,XA17y4VGM2,50.0,2022-01-01
+e653f3e14bc4,XA17y4VGM2,60.0,2022-01-06

--- a/spec/lib/tasks/import_merchants_spec.rb
+++ b/spec/lib/tasks/import_merchants_spec.rb
@@ -60,8 +60,16 @@ module Tasks
             subject
 
             error_csv = CSV.open(result_file, "r")
-            expect(error_csv.first).to eq(%w[error id reference email live_on disbursement_frequency minimum_monthly_fee])
-            expect(error_csv.first).to eq(["Data missing", "d1649242-a612-46ba-82d8-225542bb9576", "deckow_gibson", "info@deckow-gibson.com", "2022-12-14", "WEEKLY", nil])
+
+            batch = [
+              { "id"=> "86312006-4d7e-45c4-9c28-788f4aa68a62", "reference"=> "padberg_group", "email"=> "info@padberg-group.com", "live_on"=> "2023-02-01", "disbursement_frequency"=> "DAILY", "minimum_monthly_fee"=> "0.0" },
+              { "id"=> "d1649242-a612-46ba-82d8-225542bb9576", "reference"=> "deckow_gibson", "email"=> "info@deckow-gibson.com", "live_on"=> "2022-12-14",  "disbursement_frequency"=> "WEEKLY", "minimum_monthly_fee"=> nil },
+            ]
+
+            row = { "id"=> "d1649242-a612-46ba-82d8-225542bb9576", "reference"=> "deckow_gibson", "email"=> "info@deckow-gibson.com", "live_on"=> "2022-12-14",  "disbursement_frequency"=> "WEEKLY", "minimum_monthly_fee"=> nil }
+
+            expect(error_csv.first).to eq(%w[error batch row])
+            expect(error_csv.first).to eq(["Data missing", "#{batch}", "#{row}"])
           end
 
           it "should create the other merchants correctly" do
@@ -81,9 +89,11 @@ module Tasks
 
         context "when merchant creation fails" do
           before do
+            allow(Merchant).to receive(:import).and_raise(StandardError.new("Error creating"))
+  
             CSV.open("spec/fixtures/files/merchants.csv", "w") do |merchants|
               merchants << %w[id reference email live_on disbursement_frequency minimum_monthly_fee]
-              merchants << %w[86312006-4d7e-45c4-9c28-788f4aa68a62 padberg_group info@padberg-group.com invalid_date DAILY 0.0]
+              merchants << %w[86312006-4d7e-45c4-9c28-788f4aa68a62 padberg_group info@padberg-group.com 2010-02-03 DAILY 0.0]
             end
           end
 
@@ -95,8 +105,13 @@ module Tasks
             subject
 
             error_csv = CSV.open(result_file, "r")
-            expect(error_csv.first).to eq(%w[error id reference email live_on disbursement_frequency minimum_monthly_fee])
-            expect(error_csv.first).to eq(["invalid date", "86312006-4d7e-45c4-9c28-788f4aa68a62", "padberg_group", "info@padberg-group.com", "invalid_date", "DAILY", "0.0"])
+
+            batch = [
+              { "id"=> "86312006-4d7e-45c4-9c28-788f4aa68a62", "reference"=> "padberg_group", "email"=> "info@padberg-group.com", "live_on"=> "2010-02-03", "disbursement_frequency"=> "DAILY", "minimum_monthly_fee"=> "0.0" }
+            ]
+
+            expect(error_csv.first).to eq(%w[error batch row])
+            expect(error_csv.first).to eq(["Error creating", "#{batch}", "{}"])
           end
         end
       end


### PR DESCRIPTION
Addressing Issue https://github.com/fernandesleticia/merchantsdisbursementspayouts/issues/15

Bulk create orders
- Uses active record import to bulk create orders
- The bulk create reduces a lot the number of sql statements generated, making the import process faster
- This commit also update the output for errors. Now the import logs the whole row and the batch that had error