### PR TITLE
[ISSUE-19]  Add DisbursementCsvExporter to export disbursement

### DIFF
--- a/app/exporters/disbursement_csv_exporter.rb
+++ b/app/exporters/disbursement_csv_exporter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class DisbursementCsvExporter
+  attr_accessor :result_output_stream
+
+  def run
+    result_output_stream = File.open("/tmp/disbursements.csv", "w")
+    result_output_stream.write(result_output_stream_header)
+
+    query = "
+      SELECT
+        EXTRACT(YEAR FROM disbursement.created_at)::TEXT AS year,
+        COUNT(disbursement.id) AS number_of_disbursements,
+        TO_CHAR(SUM(disbursement.amount), 'FM999G999G999G999G999D00 €') AS amount_disbursed_to_merchants,
+        TO_CHAR(SUM(disbursement.commision_fee), 'FM999G999G999G999G999D00 €') AS amount_of_order_fees,
+        COUNT(monthly_fee_debit.id) AS number_of_monthly_fees_charged,
+        COALESCE(TO_CHAR(SUM(monthly_fee_debit.amount), 'FM999G999G999G999G999D00 €'), '0.00 €') AS amount_of_monthly_fee_charged
+      FROM
+        disbursements disbursement
+      LEFT JOIN
+        monthly_fee_debits monthly_fee_debit ON monthly_fee_debit.disbursement_id = disbursement.id
+      GROUP BY
+        year
+      ORDER BY
+        year
+    "
+
+    conn = ActiveRecord::Base.connection.raw_connection
+    conn.copy_data "COPY ( #{query} ) TO STDOUT WITH CSV;" do
+      while row = conn.get_copy_data
+        result_output_stream.write(row.force_encoding('UTF-8'))
+      end
+    end
+  ensure
+    result_output_stream.close
+  end
+
+  def result_output_stream_header
+    CSV.generate_line([
+      "Year",
+      "Number of disbursements",
+      "Amount disbursed to merchants",
+      "Amount of order fees",
+      "Number of monthly fees charged (From minimum monthly fee)",
+      "Amount of monthly fee charged (From minimum monthly fee)"
+    ])
+  end
+end

--- a/lib/tasks/export_disbursements.rake
+++ b/lib/tasks/export_disbursements.rake
@@ -1,0 +1,9 @@
+#frozen_string_literal: true
+
+namespace :disbursements do
+  desc "Export Disbursements"
+
+  task :export do
+    DisbursementCsvExporter.new.run
+  end
+end

--- a/spec/exporters/disbursement_csv_exporter_spec.rb
+++ b/spec/exporters/disbursement_csv_exporter_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DisbursementCsvExporter do
+  Timecop.freeze do
+    describe "#run" do
+      subject { DisbursementCsvExporter.new.run }
+
+      let(:disbursements_file) { "/tmp/disbursements.csv" }
+
+      before do
+        merchant = create(:merchant)
+        merchant2 = create(:merchant)
+
+        disbursement = create(:disbursement, created_at: 3.years.ago, amount: 1000.00, commision_fee: 10.00, merchant: merchant2)
+        create(:disbursement, created_at: 3.years.ago, amount: 1000.00, commision_fee: 10.00, merchant: merchant2)
+        create(:monthly_fee_debit, created_at: 3.years.ago, amount: 50.0, merchant: merchant2, disbursement: disbursement)
+
+        disbursement2 = create(:disbursement, created_at: 1.year.ago, amount: 1000.00, commision_fee: 10.00, merchant: merchant)
+        create(:disbursement, created_at: 1.year.ago, amount: 1000.00, commision_fee: 10.00, merchant: merchant)
+        create(:disbursement, created_at: 1.year.ago, amount: 500.00, commision_fee: 1.00, merchant: merchant)
+        create(:monthly_fee_debit, created_at: 1.year.ago, amount: 50.0, merchant: merchant, disbursement: disbursement2)
+
+        create(:disbursement, created_at: Date.today, amount: 200.00, commision_fee: 20.00, merchant: merchant)
+        create(:disbursement, created_at: Date.today, amount: 200.00, commision_fee: 20.00, merchant: merchant2)
+      end
+
+      after(:each) do
+        File.delete(disbursements_file) if File.exist?(disbursements_file)
+      end
+
+      it "should export disbursements correctly" do
+        subject
+
+        disbursements_csv = CSV.open(disbursements_file, "r")
+
+        expect(disbursements_csv.first).to eq([
+          "Year",
+          "Number of disbursements",
+          "Amount disbursed to merchants",
+          "Amount of order fees",
+          "Number of monthly fees charged (From minimum monthly fee)",
+          "Amount of monthly fee charged (From minimum monthly fee)"
+        ])
+
+        expect(disbursements_csv.first).to eq(["2020", "2", "2,000.00 €", "20.00 €", "1", "50.00 €"])
+        expect(disbursements_csv.first).to eq(["2022", "3", "2,500.00 €", "21.00 €", "1", "50.00 €"])
+        expect(disbursements_csv.first).to eq(["2023", "2", "400.00 €", "40.00 €", "0", "0.00 €"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addressing Issue https://github.com/fernandesleticia/merchantsdisbursementspayouts/issues/19

Add disbursement export
- Create rake task used for exporting disbursement report
- Create disbursement CSV exporter
- Create a query to export disbursements
- Copy query data to a CSV